### PR TITLE
One file per ADR and simplified markdown

### DIFF
--- a/templates/captureTemplate_full.md
+++ b/templates/captureTemplate_full.md
@@ -1,97 +1,36 @@
-# [Short Title of the Issue]
-**UserStory:** *[TICKET/ISSUE-NUMBER]*
+# <Short Title of the Issue>
 
-*[WRITE ONE SENTENCE DESCRIBING THE PROBLEM.]* (Optional)
+**UserStory:** <TICKET/ISSUE-NUMBER>
 
-## Considered Alternatives:
-* [ALTERNATIVE 1]
-* [ALTERNATIVE 2]
-* [ALTERNATIVE 3]
+<WRITE ONE SENTENCE DESCRIBING THE PROBLEM. (Optional)>
 
-## Conclusion
-* *Chosen Alternative: [ALTERNATIVE 1]*
-* *[FURTHER RATIONALE]* (Optional)
+## Considered Alternatives
 
-## Comparison (Optional)
-### [ALTERNATIVE 1]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
-
-### [ALTERNATIVE 2]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
-
-### [ALTERNATIVE 3]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-# [Short Title of the Issue]
-**UserStory:** *[TICKET/ISSUE-NUMBER]*
-
-*[WRITE ONE SENTENCE DESCRIBING THE PROBLEM.]* (Optional)
-
-## Considered Alternatives:
-* [ALTERNATIVE 1]
-* [ALTERNATIVE 2]
-* [ALTERNATIVE 3]
+* <ALTERNATIVE 1>
+* <ALTERNATIVE 2>
+* <ALTERNATIVE 3>
 
 ## Conclusion
-* *Chosen Alternative: [ALTERNATIVE 1]*
-* *[FURTHER RATIONALE]* (Optional)
+
+* *Chosen Alternative: <ALTERNATIVE 1>*
+* <FURTHER RATIONALE (Optional)>
 
 ## Comparison (Optional)
-### [ALTERNATIVE 1]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
 
-### [ALTERNATIVE 2]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
+### <ALTERNATIVE 1>
 
-### [ALTERNATIVE 3]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
+* + <ARGUMENT 1 PRO>
+* + <ARGUMENT 2 PRO>
+* - <ARGUMENT 1 CONTRA>
 
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
+### <ALTERNATIVE 2>
 
-# [Short Title of the Issue]
-**UserStory:** *[TICKET/ISSUE-NUMBER]*
+* + <ARGUMENT 1 PRO>
+* + <ARGUMENT 2 PRO>
+* - <ARGUMENT 1 CONTRA>
 
-*[WRITE ONE SENTENCE DESCRIBING THE PROBLEM.]* (Optional)
+### <ALTERNATIVE 3>
 
-## Considered Alternatives:
-* [ALTERNATIVE 1]
-* [ALTERNATIVE 2]
-* [ALTERNATIVE 3]
-
-## Conclusion
-* *Chosen Alternative: [ALTERNATIVE 1]*
-* *[FURTHER RATIONALE]* (Optional)
-
-## Comparison (Optional)
-### [ALTERNATIVE 1]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
-
-### [ALTERNATIVE 2]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
-
-### [ALTERNATIVE 3]
-* *+ [ARGUMENT 1 PRO]*
-* *+ [ARGUMENT 2 PRO]*
-* *- [ARGUMENT 1 CONTRA]*
+* + <ARGUMENT 1 PRO>
+* + <ARGUMENT 2 PRO>
+* - <ARGUMENT 1 CONTRA>

--- a/templates/captureTemplate_simple.md
+++ b/templates/captureTemplate_simple.md
@@ -1,49 +1,16 @@
-# [Short Title of the Issue]
-**UserStory:** *[TICKET/ISSUE-NUMBER]*
+# <Short Title of the Issue>
 
-*[WRITE ONE SENTENCE DESCRIBING THE PROBLEM.]* (Optional)
+**UserStory:** <TICKET/ISSUE-NUMBER>
 
-## Considered Alternatives:
-* [ALTERNATIVE 1]
-* [ALTERNATIVE 2]
-* [ALTERNATIVE 3]
-
-## Conclusion
-* *Chosen Alternative: [ALTERNATIVE 1]*
-* *[FURTHER RATIONALE]* (Optional)
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-# [Short Title of the Issue]
-**UserStory:** *[TICKET/ISSUE-NUMBER]*
-
-*[WRITE ONE SENTENCE DESCRIBING THE PROBLEM.]* (Optional)
+<WRITE ONE SENTENCE DESCRIBING THE PROBLEM.] (Optional)>
 
 ## Considered Alternatives:
-* [ALTERNATIVE 1]
-* [ALTERNATIVE 2]
-* [ALTERNATIVE 3]
+
+* <ALTERNATIVE 1>
+* <ALTERNATIVE 2>
+* <ALTERNATIVE 3>
 
 ## Conclusion
-* *Chosen Alternative: [ALTERNATIVE 1]*
-* *[FURTHER RATIONALE]* (Optional)
 
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-# [Short Title of the Issue]
-**UserStory:** *[TICKET/ISSUE-NUMBER]*
-
-*[WRITE ONE SENTENCE DESCRIBING THE PROBLEM.]* (Optional)
-
-## Considered Alternatives:
-* [ALTERNATIVE 1]
-* [ALTERNATIVE 2]
-* [ALTERNATIVE 3]
-
-## Conclusion
-* *Chosen Alternative: [ALTERNATIVE 1]*
-* *[FURTHER RATIONALE]* (Optional)
+* *Chosen Alternative: <ALTERNATIVE 1>*
+* <FURTHER RATIONALE (Optional)>


### PR DESCRIPTION
# One file per ADR

Currently, there are more than one ADRs in a file and this is uncommon. One ADR per file is inspired by https://github.com/npryce/adr-tools/tree/master/doc/adr and https://github.com/joelparkerhenderson/architecture_decision_record#adr-file-name-conventions

## Considered Alterantrives

* Update template only
* Update all examples

## Conclusion

* *Chosen Alternative: Update template only*

## Comparison

### Update template only
* + Easier for review
* - No complete picture

## Consequences

If merged, the examples have to be updated. Further, the file naming has to thought. Maybe the pattern `Sprint 01 - 01 - Decision.md` would be useful?

# Simplified markdown

The current markdown is uncommon. Placeholders are mostly written in `<...>` and not using `*`

## Considered Alternatives

* Keep everything as is
* Simplify markdown

## Conclusion

* Chosen Alternative: Simplify markdown